### PR TITLE
feat: Enable proper GitOps workflow by fixing reconciliation logic

### DIFF
--- a/kell/operator/internal/controller/staticwebsite_controller.go
+++ b/kell/operator/internal/controller/staticwebsite_controller.go
@@ -31,6 +31,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
+	"github.com/go-logr/logr"
 	webappv1alpha1 "github.com/jesusxy/bit-by-bit/kell/operator/api/v1alpha1"
 )
 
@@ -74,34 +75,36 @@ func (r *StaticWebsiteReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 
 	// --- Deployment Reconciliation ---
 	foundDeployment := &appsv1.Deployment{}
-	desiredDeployment := r.deploymentForStaticWebsite(staticWebsite)
 	err = r.Get(ctx, types.NamespacedName{Name: staticWebsite.Name, Namespace: staticWebsite.Namespace}, foundDeployment)
 
 	if err != nil && errors.IsNotFound(err) {
 		// create new dployment
+		desiredDeployment := r.deploymentForStaticWebsite(staticWebsite)
 		logger.Info("Creating New Deployment", "Deployment.Namespace", desiredDeployment.Namespace, "Deployment.Name", desiredDeployment.Name)
 		err = r.Create(ctx, desiredDeployment)
 		if err != nil {
 			logger.Error(err, "Failed to create new Deployment")
-			return ctrl.Result{Requeue: true}, nil
+			return ctrl.Result{}, err
 		}
-	} else if err == nil {
-		// deployment found
-		if !reflect.DeepEqual(desiredDeployment.Spec, foundDeployment.Spec) {
-			logger.Info("Deployment spec is out of date, updating...")
-			foundDeployment.Spec = desiredDeployment.Spec
-			err = r.Update(ctx, foundDeployment)
-
-			if err != nil {
-				logger.Error(err, "Failed to update Deployment")
-				return ctrl.Result{}, err
-			}
-
-			return ctrl.Result{Requeue: true}, nil
-		}
-	} else {
+		return ctrl.Result{}, nil
+	} else if err != nil {
 		logger.Error(err, "Failed to get deployment")
 		return ctrl.Result{}, err
+	}
+
+	desiredDeployment := r.deploymentForStaticWebsite(staticWebsite)
+	if r.deploymentNeedsUpdate(foundDeployment, desiredDeployment, logger) {
+		logger.Info("Deployment spec is out of date, updating...")
+
+		r.updateDeploymentSpec(foundDeployment, desiredDeployment)
+
+		err = r.Update(ctx, foundDeployment)
+		if err != nil {
+			logger.Error(err, "Failed to update deployment")
+			return ctrl.Result{}, err
+		}
+
+		return ctrl.Result{}, nil
 	}
 
 	// --- Service Reconciliation ---\
@@ -117,7 +120,7 @@ func (r *StaticWebsiteReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 			logger.Error(err, "Failed to create a new Service", "Service.Namespace", desiredService.Namespace, "Service.Name", desiredService.Name)
 			return ctrl.Result{}, err
 		}
-		return ctrl.Result{Requeue: true}, nil
+		return ctrl.Result{}, nil
 	} else if err != nil {
 		logger.Error(err, "Failed to get Service")
 		return ctrl.Result{}, err
@@ -129,9 +132,82 @@ func (r *StaticWebsiteReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	return ctrl.Result{}, nil
 }
 
+func (r *StaticWebsiteReconciler) deploymentNeedsUpdate(found, desired *appsv1.Deployment, logger logr.Logger) bool {
+	if found.Spec.Replicas == nil || *found.Spec.Replicas != *desired.Spec.Replicas {
+		logger.Info("Replica count differs", "found", found.Spec.Replicas, "desired", *desired.Spec.Replicas)
+		return true
+	}
+
+	foundInitContainers := r.normalizeContainers(found.Spec.Template.Spec.InitContainers)
+	desiredInitContainers := r.normalizeContainers(desired.Spec.Template.Spec.InitContainers)
+
+	if !reflect.DeepEqual(foundInitContainers, desiredInitContainers) {
+		logger.Info("Init containers differ")
+		logger.Info("Found init containers", "containers", foundInitContainers)
+		logger.Info("Desired init containers", "containers", desiredInitContainers)
+		return true
+	}
+
+	foundContainers := r.normalizeContainers(found.Spec.Template.Spec.Containers)
+	desiredContainers := r.normalizeContainers(desired.Spec.Template.Spec.Containers)
+
+	if !reflect.DeepEqual(foundContainers, desiredContainers) {
+		logger.Info("Main containers differ")
+		logger.Info("Found containers", "containers", foundContainers)
+		logger.Info("Desired containers", "containers", desiredContainers)
+		return true
+	}
+
+	if !reflect.DeepEqual(found.Spec.Template.Spec.Volumes, desired.Spec.Template.Spec.Volumes) {
+		logger.Info("Volumes differ")
+		logger.Info("Found volumes", "volumes", found.Spec.Template.Spec.Volumes)
+		logger.Info("Desired volumes", "volumes", desired.Spec.Template.Spec.Volumes)
+		return true
+	}
+
+	return false
+}
+
+func (r *StaticWebsiteReconciler) normalizeContainers(containers []corev1.Container) []corev1.Container {
+	normalized := make([]corev1.Container, len(containers))
+	copy(normalized, containers)
+
+	for i := range normalized {
+		// clear fields that Kubernetes auto-populates
+		normalized[i].TerminationMessagePath = ""
+		normalized[i].TerminationMessagePolicy = ""
+		normalized[i].ImagePullPolicy = ""
+
+		if normalized[i].Resources.Limits == nil && normalized[i].Resources.Requests == nil {
+			normalized[i].Resources = corev1.ResourceRequirements{}
+		}
+
+		if normalized[i].SecurityContext != nil {
+			if normalized[i].SecurityContext.RunAsNonRoot == nil &&
+				normalized[i].SecurityContext.ReadOnlyRootFilesystem == nil &&
+				normalized[i].SecurityContext.AllowPrivilegeEscalation == nil &&
+				normalized[i].SecurityContext.RunAsUser == nil &&
+				normalized[i].SecurityContext.RunAsGroup == nil {
+				normalized[i].SecurityContext = nil
+			}
+		}
+	}
+
+	return normalized
+}
+
+func (r *StaticWebsiteReconciler) updateDeploymentSpec(found, desired *appsv1.Deployment) {
+	found.Spec.Replicas = desired.Spec.Replicas
+	found.Spec.Template.Spec.InitContainers = desired.Spec.Template.Spec.InitContainers
+	found.Spec.Template.Spec.Containers = desired.Spec.Template.Spec.Containers
+	found.Spec.Template.Spec.Volumes = desired.Spec.Template.Spec.Volumes
+
+	if !reflect.DeepEqual(found.Spec.Template.ObjectMeta.Labels, desired.Spec.Template.ObjectMeta.Labels) {
+		found.Spec.Template.ObjectMeta.Labels = desired.Spec.Template.ObjectMeta.Labels
+	}
+}
+
 func (r *StaticWebsiteReconciler) deploymentForStaticWebsite(sw *webappv1alpha1.StaticWebsite) *appsv1.Deployment {
-	logger := log.FromContext(context.Background())
-	logger.Info(">>> Using V3 deployment logic with bitnami/git and explicit command <<<")
 	labels := map[string]string{"app": sw.Name}
 	replicas := sw.Spec.Replicas
 
@@ -184,6 +260,7 @@ func (r *StaticWebsiteReconciler) deploymentForStaticWebsite(sw *webappv1alpha1.
 						Ports: []corev1.ContainerPort{{
 							ContainerPort: 80,
 							Name:          "http",
+							Protocol:      corev1.ProtocolTCP,
 						}},
 						VolumeMounts: []corev1.VolumeMount{{
 							Name:      "web-content",


### PR DESCRIPTION
### Problem
The StaticWebsite operator required manual intervention for configuration changes. When users updated their StaticWebsite specs (replica count, git repo, etc.), the changes wouldn't automatically apply. Users had to manually run:
```bash
bashkubectl delete deployment my-first-website
# Wait for operator to recreate
```

This breaks the fundamental GitOps promise: "change the spec, see the change applied automatically."

### Root Cause
The controller was stuck in an infinite reconciliation loop due to Kubernetes default value mismatches. The comparison logic always detected "differences" between:

- Found deployment (with Kubernetes auto-added defaults)
- Desired deployment (our clean spec without defaults)

This caused the controller to continuously update without ever reaching a stable state, preventing it from detecting and applying real configuration changes.

```
Evidence:
INFO    Deployment spec is out of date, updating...
INFO    Deployment spec is out of date, updating...  
INFO    Deployment spec is out of date, updating...
# ...infinitely
```


### Solution: Enable True GitOps Workflow
**Goal:** Make configuration changes apply automatically without manual intervention.
**Approach:** Fix the reconciliation logic by setting explicit defaults to match Kubernetes behavior.

#### Now Users Can:
✅ Update replica count → automatic deployment scaling
✅ Change git repository → automatic redeployment with new content
✅ Modify any StaticWebsite spec → automatic reconciliation
✅ Use standard GitOps workflows → commit → apply → see changes