### PR TITLE
feat(cli): Add 'list' command to display container status

### DIFF
--- a/ror/cmd/ror/list_cli.go
+++ b/ror/cmd/ror/list_cli.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"text/tabwriter"
+
+	"github.com/jesuskeys/bit-by-bit/ror/internal/runner"
+	"github.com/urfave/cli/v3"
+)
+
+func newListCmd(r *runner.Runner) *cli.Command {
+	return &cli.Command{
+		Name:    "list",
+		Usage:   "List all containers",
+		Aliases: []string{"ls"},
+		Action: func(ctx context.Context, c *cli.Command) error {
+			containers, err := r.ListContainers()
+
+			if err != nil {
+				return fmt.Errorf("failed to list containers : %w", err)
+			}
+
+			w := tabwriter.NewWriter(os.Stdout, 12, 1, 3, ' ', 0)
+			fmt.Fprintf(w, "ID\tSTATUS\tPID\tBUNDLE\n")
+
+			for _, c := range containers {
+				fmt.Fprintf(w, "%s\t%s\t%d\t%s\n", c.ID, c.Status, c.PID, c.Bundle)
+			}
+
+			return w.Flush()
+		},
+	}
+}

--- a/ror/cmd/ror/main.go
+++ b/ror/cmd/ror/main.go
@@ -52,6 +52,7 @@ func main() {
 			newCreateCmd(runner),
 			newStartCmd(runner),
 			newDeleteCmd(runner),
+			newListCmd(runner),
 		},
 	}
 

--- a/ror/internal/runner/list.go
+++ b/ror/internal/runner/list.go
@@ -1,0 +1,78 @@
+package runner
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"syscall"
+
+	"github.com/jesuskeys/bit-by-bit/ror/internal/constants"
+)
+
+type ContainerInfo struct {
+	ID     string
+	Status string
+	PID    int
+	Bundle string
+}
+
+func (r *Runner) ListContainers() ([]ContainerInfo, error) {
+	entries, err := os.ReadDir(r.BasePath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read state directory: %w", err)
+	}
+
+	var containers []ContainerInfo
+
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+
+		containerId := entry.Name()
+		info := ContainerInfo{ID: containerId}
+
+		statePath := filepath.Join(r.BasePath, containerId)
+		pidFilePath := filepath.Join(statePath, constants.PIDFileName)
+		bundleFilePath := filepath.Join(statePath, constants.BundlePathFileName)
+
+		bundlePathBytes, err := os.ReadFile(bundleFilePath)
+		if err == nil {
+			info.Bundle = string(bundlePathBytes)
+		}
+
+		pidData, err := os.ReadFile(pidFilePath)
+		if os.IsNotExist(err) {
+			info.Status = "created"
+			containers = append(containers, info)
+			continue
+		}
+
+		pid, err := strconv.Atoi(string(pidData))
+		if err != nil {
+			info.Status = "stopped"
+			containers = append(containers, info)
+			continue
+		}
+		info.PID = pid
+
+		// check if process is actually running, by sending null signal
+		process, err := os.FindProcess(pid)
+		if err != nil {
+			info.Status = "stopped"
+			containers = append(containers, info)
+			continue
+		}
+
+		err = process.Signal(syscall.Signal(0))
+		if err == nil {
+			info.Status = "running"
+		} else {
+			info.Status = "stopped"
+		}
+		containers = append(containers, info)
+	}
+
+	return containers, nil
+}


### PR DESCRIPTION
## Description
This pull request adds an essential management feature to the ror runtime: a list command (with a ls alias). This command provides users with a high-level, formatted overview of all created containers and their current operational state.

This change makes the runtime significantly more usable by allowing users to track and manage multiple containers at a glance.

## Implementation Details
  - New list Subcommand: A new list command has been added to the main CLI application.
  - Container State Discovery: The core logic scans the runtime's base directory, treating each subdirectory as a unique container.
  - Status Detection Logic: The status of each container (created, running, or stopped) is determined by:
    1. Checking for the existence of a pid file in the container's state directory.
    2. If a pid file exists, reading the PID and sending a null signal (syscall.Signal(0)) to the process to verify if it is currently active.
  - Formatted Output: The command uses Go's text/tabwriter package to produce a clean, aligned table displaying the following metadata for each container:
    - ID
    - STATUS
    - PID
    - BUNDLE