### PR TITLE
feat: Add GeoIP Enrichment and New Country Detection Rule

### DIFF
--- a/nox/.gitignore
+++ b/nox/.gitignore
@@ -1,0 +1,1 @@
+testdata/GeoLite2-City.mmdb

--- a/nox/cmd/nox/main.go
+++ b/nox/cmd/nox/main.go
@@ -3,12 +3,21 @@ package main
 import (
 	"fmt"
 	"log"
+	"net"
 	"nox/internal/ingester"
 	"nox/internal/model"
 	"nox/internal/rules"
+
+	"github.com/oschwald/geoip2-golang"
 )
 
 func main() {
+	db, err := geoip2.Open("testdata/GeoLite2-City.mmdb")
+	if err != nil {
+		log.Fatalf("Error opening GeoIP database: %v", err)
+	}
+	defer db.Close()
+
 	eventChannel := make(chan model.Event, 100) // channel that holds 100 events
 	stateManager := rules.NewStateManager()
 
@@ -16,6 +25,14 @@ func main() {
 	log.Println("Nox IDS engine started. Tailing log file...")
 
 	for event := range eventChannel {
+		ip := net.ParseIP(event.Source)
+		if ip != nil {
+			record, err := db.Country(ip)
+			if err == nil && record.Country.IsoCode != "" {
+				event.Metadata["country"] = record.Country.IsoCode // e.g "US", "CN", "DE"
+			}
+		}
+
 		triggeredAlerts := rules.EvaluateEvent(event, stateManager)
 
 		for _, alert := range triggeredAlerts {

--- a/nox/go.mod
+++ b/nox/go.mod
@@ -4,6 +4,8 @@ go 1.24.2
 
 require (
 	github.com/hpcloud/tail v1.0.0 // indirect
+	github.com/oschwald/geoip2-golang v1.13.0 // indirect
+	github.com/oschwald/maxminddb-golang v1.13.0 // indirect
 	golang.org/x/sys v0.35.0 // indirect
 	gopkg.in/fsnotify.v1 v1.4.7 // indirect
 	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect

--- a/nox/go.sum
+++ b/nox/go.sum
@@ -1,5 +1,9 @@
 github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
+github.com/oschwald/geoip2-golang v1.13.0 h1:Q44/Ldc703pasJeP5V9+aFSZFmBN7DKHbNsSFzQATJI=
+github.com/oschwald/geoip2-golang v1.13.0/go.mod h1:P9zG+54KPEFOliZ29i7SeYZ/GM6tfEL+rgSn03hYuUo=
+github.com/oschwald/maxminddb-golang v1.13.0 h1:R8xBorY71s84yO06NgTmQvqvTvlS/bnYZrrWX1MElnU=
+github.com/oschwald/maxminddb-golang v1.13.0/go.mod h1:BU0z8BfFVhi1LQaonTwwGQlsHUEu9pWNdMfmq4ztm0o=
 golang.org/x/sys v0.35.0 h1:vz1N37gP5bs89s7He8XuIYXpyY0+QlsKmzipCbUtyxI=
 golang.org/x/sys v0.35.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
 gopkg.in/fsnotify.v1 v1.4.7 h1:xOHLXZwVvI9hhs+cLKq5+I5onOuwQLhQwiu63xxlHs4=

--- a/nox/internal/ingester/ingester.go
+++ b/nox/internal/ingester/ingester.go
@@ -12,6 +12,9 @@ import (
 	"github.com/hpcloud/tail"
 )
 
+// Example Logs:
+// Aug 24 13:30:00 my-server sshd[8888]: Accepted password for jsmith from 192.168.1.50 port 12345 ssh2
+
 type logParser struct {
 	EventType string
 	Regex     *regexp.Regexp
@@ -26,6 +29,18 @@ var parsers = []logParser{
 			return model.Event{
 				Timestamp: time.Now().UTC(),
 				EventType: "SSHD_Failed_Password",
+				Source:    matches[2],
+				Metadata:  map[string]string{"user": matches[1]},
+			}, nil
+		},
+	},
+	{
+		EventType: "SSHD_Accepted_Password",
+		Regex:     regexp.MustCompile(`Accepted password for (\S+) from ([\d\.]+) port \d+ ssh2`),
+		Builder: func(matches []string) (model.Event, error) {
+			return model.Event{
+				Timestamp: time.Now().UTC(),
+				EventType: "SSHD_Accepted_Password",
 				Source:    matches[2],
 				Metadata:  map[string]string{"user": matches[1]},
 			}, nil

--- a/nox/testdata/auth.log
+++ b/nox/testdata/auth.log
@@ -12,3 +12,6 @@ Aug 24 02:20:00 my-server sshd[6666]: Failed password for user hacker from 10.10
 Aug 24 02:20:00 my-server sshd[6666]: Failed password for user hacker from 10.10.10.10 port 22 ssh2
 Aug 24 02:20:00 my-server sshd[6666]: Failed password for user hacker from 10.10.10.10 port 22 ssh2
 Aug 24 02:20:00 my-server sshd[6666]: Failed password for user hacker from 10.10.10.10 port 22 ssh2
+Aug 24 14:00:00 my-server sshd[1111]: Accepted password for jsmith from 8.8.8.8 port 12345 ssh2
+Aug 24 14:01:00 my-server sshd[2222]: Accepted password for jsmith from 8.8.4.4 port 12345 ssh2
+Aug 24 14:02:00 my-server sshd[3333]: Accepted password for jsmith from 193.99.144.80 port 12345 ssh2


### PR DESCRIPTION
## Summary
This PR implements Phase 3 of the project plan, making the nox engine significantly smarter by introducing event enrichment. The core change is the addition of a GeoIP lookup step that adds the country of origin to events based on their source IP address.

This new, enriched data enables a new class of behavioral detection rules, the first of which is the "New Country Login" rule, which triggers an alert when a user logs in from a new geographic location for the first time.

## Changes
- GeoIP Enrichment: The main event loop now enriches each incoming event with the source IP's country code before passing it to the rules engine.
- New Accepted Password Parser: The ingester was updated to parse successful SSH logins, which is necessary to attribute a login to a specific user.
- New Rule: checkNewCountryLogin: A new stateful rule was implemented to track user login locations and fire an alert upon the first login from a new country.
- Expanded StateManager: The state manager now includes a map to maintain a history of which countries a user has logged in from.
- Integrated MaxMind GeoLite2: Added the oschwald/geoip2-golang library and integrated the GeoLite2 database for IP lookups.
- Updated .gitignore: The large .mmdb database file is now correctly ignored by Git to keep the repository lightweight.